### PR TITLE
also for Grunt. Add task folder for grunt.loadNpmTask

### DIFF
--- a/GruntFile.js
+++ b/GruntFile.js
@@ -1,0 +1,11 @@
+module.exports = function(grunt) {
+  grunt.initConfig({
+    protractorperf: {
+      options: {
+          configFile: "./grunt-test/conf.js",
+      }
+    }
+  });
+  grunt.loadNpmTasks('protractor-perf');
+  grunt.registerTask('perf', 'protractorperf');
+};

--- a/grunt-test/conf.js
+++ b/grunt-test/conf.js
@@ -1,0 +1,27 @@
+// An example configuration file.
+exports.config = {
+  // The address of a running selenium server.
+  // seleniumAddress: 'http://localhost:4444/wd/hub',
+
+  // if we are using protractor's webdriver-manager locally, you cannot use selenium Address
+  // If the webdriver-manager needs to start a local server, you can use 
+  selenium: 'http://localhost:12345/wd/hub',
+  seleniumPort: 12345, // Port matches the port above
+
+  // Capabilities to be passed to the webdriver instance.
+  capabilities: {
+    'browserName': 'chrome'
+  },
+
+  // Spec patterns are relative to the current working directly when
+  // protractor is called.
+  specs: ['example.spec.js'],
+
+  // Options to be passed to Jasmine-node.
+  jasmineNodeOpts: {
+    showColors: true,
+    defaultTimeoutInterval: 300000
+  },
+
+  allScriptsTimeout: 200000
+};

--- a/grunt-test/example.spec.js
+++ b/grunt-test/example.spec.js
@@ -1,0 +1,23 @@
+var PerfRunner = require('protractor-perf');
+describe('angularjs homepage todo list', function() {
+	var perfRunner = new PerfRunner(protractor, browser);
+
+	it('should add a todo', function() {
+		browser.get('http://www.angularjs.org');
+		perfRunner.start();
+
+		element(by.model('todoList.todoText')).sendKeys('write a protractor test');
+		element(by.css('[value="add"]')).click();
+
+		perfRunner.stop();
+
+		if (perfRunner.isEnabled) {
+			perfRunner.printStats();
+			expect(perfRunner.getStats('meanFrameTime')).toBeLessThan(60);
+		};
+
+		var todoList = element.all(by.repeater('todo in todoList.todos'));
+		expect(todoList.count()).toEqual(3);
+		expect(todoList.get(2).getText()).toEqual('write a protractor test');
+	});
+});

--- a/tasks/protractor-perf.js
+++ b/tasks/protractor-perf.js
@@ -1,0 +1,12 @@
+/* 
+ * grunt-protractor-perf
+ */
+'use strict';
+var protractorperf = require('protractor-perf');
+
+module.exports = function(grunt) {
+	grunt.registerTask('protractorperf', function() {
+	var donerun = this.async();
+	protractorperf.run(this.options()['configFile'], donerun)
+	});
+}


### PR DESCRIPTION
Add task folder, in order to use grunt.loadNpmTasks('protractor-perf'). 
the config of protractor can be added in grunt.initConfig. If the file is not fount, grunt will throw Error.

as in GruntFile.js shows, command 'grunt perf' can be used to run this task. 
test-grunt ... is actually the same sample tests before, but when using grunt, 
require('..') is not valid in example_spec.js any more.
