### PR TITLE
support of Protractor 3.x.x

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -6,7 +6,7 @@
  *
  * Values from command line options override values from the config.
  */
- 
+
 'use strict';
 
 var args = [];
@@ -142,13 +142,13 @@ if (!configFile && !argv.elementExplorer && args.length < 3) {
 
 
 // Added for Protractor-Perf
-var ConfigParser = require('protractor/lib/configParser');
+var ConfigParser = require('protractor/built/configParser').default;
 var configParser = new ConfigParser();
 configParser.addFileConfig(configFile);
 configParser.addConfig(argv);
 require('..').getConfig(configParser.getConfig(), function(data) {
   // Run the launcher
-  require('protractor/lib/launcher').init(undefined, data);
+  require('protractor/built/launcher').init(undefined, data);
 });
 
 //END OF FILE


### PR DESCRIPTION
configParser + launcher were moved to 'build' library
