### PR TITLE
Adds compatibility to old versions of protractor/ConfigParser

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -142,7 +142,8 @@ if (!configFile && !argv.elementExplorer && args.length < 3) {
 
 
 // Added for Protractor-Perf
-var ConfigParser = require('protractor/built/configParser').ConfigParser;
+var reqConfigParser = require('protractor/built/configParser');
+var ConfigParser = reqConfigParser.default || reqConfigParser.ConfigParser;
 var configParser = new ConfigParser();
 configParser.addFileConfig(configFile);
 configParser.addConfig(argv);


### PR DESCRIPTION
regarding issue #41

I wasn't able to run npm test, for some reason I couldn't connect to the selenium webdriver.

Is this task working properly? If not we can create a new issue to fix that :)
